### PR TITLE
libvirtd service: Move mutable configs to /var

### DIFF
--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -122,18 +122,14 @@ in
             chmod 755 /var/lib/libvirt
             chmod 755 /var/lib/libvirt/dnsmasq
 
-            # Libvirt unfortunately writes mutable state (such as
-            # runtime changes to VM, network or filter configurations)
-            # to /etc.  So we can't use environment.etc to make the
-            # default network and filter definitions available, since
-            # libvirt will then modify the originals in the Nix store.
-            # So here we copy them instead.  Ugly.
-            for i in $(cd ${pkgs.libvirt}/etc && echo \
+            # Copy default libvirt network config .xml files to /var/lib
+            # Files modified by the user will not be overwritten
+            for i in $(cd ${pkgs.libvirt}/var/lib && echo \
                 libvirt/qemu/networks/*.xml libvirt/qemu/networks/autostart/*.xml \
                 libvirt/nwfilter/*.xml );
             do
-                mkdir -p /etc/$(dirname $i) -m 755
-                cp -fpd ${pkgs.libvirt}/etc/$i /etc/$i
+                mkdir -p /var/lib/$(dirname $i) -m 755
+                cp -npd ${pkgs.libvirt}/var/lib/$i /var/lib/$i
             done
 
             # libvirtd puts the full path of the emulator binary in the machine

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   configureFlags = [
     "--localstatedir=/var"
-    "--sysconfdir=/etc"
+    "--sysconfdir=/var/lib"
     "--with-init-script=redhat"
     "--with-macvtap"
     "--with-virtualport"
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
   installFlags = [
     "localstatedir=$(TMPDIR)/var"
-    "sysconfdir=$(out)/etc"
+    "sysconfdir=$(out)/var/lib"
   ];
 
   postInstall = ''


### PR DESCRIPTION
Modifies libvirt package to search for configs in /var/lib and changes
libvirtd service to copy the default configs to the new location.

This enables the user to change e.g. the networking configuration with
virsh or virt-manager and keep those settings.
