### PR TITLE
Default to gcc6

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4457,7 +4457,7 @@ in
 
   gambit = callPackage ../development/compilers/gambit { };
 
-  gcc = gcc5;
+  gcc = gcc6;
 
   wrapCCMulti = cc:
     if system == "x86_64-linux" then lowPrio (


### PR DESCRIPTION
###### Motivation for this change

hydra langweilt sich :wink: 
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [x] OS X
  - [x] Linux
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

:innocent:
CC @fpletz
