### PR TITLE
prometheus alertmanager module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -293,6 +293,7 @@
   ./services/monitoring/prometheus/default.nix
   ./services/monitoring/prometheus/nginx-exporter.nix
   ./services/monitoring/prometheus/node-exporter.nix
+  ./services/monitoring/prometheus/alertmanager.nix
   ./services/monitoring/riemann.nix
   ./services/monitoring/riemann-dash.nix
   ./services/monitoring/riemann-tools.nix

--- a/nixos/modules/services/monitoring/prometheus/alertmanager.nix
+++ b/nixos/modules/services/monitoring/prometheus/alertmanager.nix
@@ -1,0 +1,106 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.services.alertmanager;
+  mkConfigFile = pkgs.writeText "alertmanager.yml" cfg.configuration;
+in {
+  options = {
+    services.alertmanager = {
+      enable = mkEnableOption "Prometheus Alertmanager";
+
+      user = mkOption {
+        type = types.str;
+        default = "root";
+        description = ''
+          Username under which Alertmanager shall be run.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "root";
+        description = ''
+          Group under which Alertmanager shall be run.
+        '';
+      };
+
+      configuration = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Alertmanager configuration.
+        '';
+      };
+
+      logFormat = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          If set use a syslog logger or JSON logging.
+        '';
+      };
+
+      logLevel = mkOption {
+        type = types.str;
+        default = "warn";
+        description = ''
+    	    Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal].
+        '';
+      };
+
+      webExternalUrl = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+    	    The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy).
+          Used for generating relative and absolute links back to Alertmanager itself.
+          If the URL has a path portion, it will be used to prefix all HTTP endoints served by Alertmanager.
+          If omitted, relevant URL components will be derived automatically.
+        '';
+      };
+
+      webListenAddress = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Address to listen on for the web interface and API.
+        '';
+      };
+
+      webListenPort = mkOption {
+        type = types.int;
+        default = 9093;
+        description = ''
+          Port to listen on for the web interface and API. (default "9093")
+        '';
+      };
+    };
+  };
+
+
+  config = mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = [ cfg.port ];
+    systemd.services.alertmanager = {
+      wantedBy = [ "multi-user.target" ];
+      after    = [ "network.target" ];
+      script = ''
+        ${pkgs.prometheus-alertmanager.bin}/bin/alertmanager \
+        -config.file ${mkConfigFile} \
+        -web.listen-address ${cfg.webListenAddress}:${toString cfg.webListenPort} \
+        -log.level ${cfg.logLevel} \
+        ${optionalString (cfg.webExternalUrl != "") ''-web.external-url ${cfg.webExternalUrl} \''}
+        ${optionalString (cfg.logFormat != "") "-log.format ${cfg.logFormat}"}
+      '';
+
+      serviceConfig = {
+        User = "${cfg.user}";
+        Group = "${cfg.group}";
+        Restart  = "always";
+        PrivateTmp = true;
+        WorkingDirectory = /tmp;
+      };
+    };
+  };
+}

--- a/nixos/modules/services/monitoring/prometheus/alertmanager.nix
+++ b/nixos/modules/services/monitoring/prometheus/alertmanager.nix
@@ -27,10 +27,10 @@ in {
       };
 
       configuration = mkOption {
-        type = types.str;
-        default = "";
+        type = types.attrs;
+        default = {};
         description = ''
-          Alertmanager configuration.
+          Alertmanager configuration as nix attribute set.
         '';
       };
 
@@ -46,15 +46,15 @@ in {
         type = types.enum ["debug" "info" "warn" "error" "fatal"];
         default = "warn";
         description = ''
-    	    Only log messages with the given severity or above.
+          Only log messages with the given severity or above.
         '';
       };
 
       webExternalUrl = mkOption {
-        type = types.str;
-        default = "";
+        type = types.nullOr types.str;
+        default = null;
         description = ''
-    	    The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy).
+          The URL under which Alertmanager is externally reachable (for example, if Alertmanager is served via a reverse proxy).
           Used for generating relative and absolute links back to Alertmanager itself.
           If the URL has a path portion, it will be used to prefix all HTTP endoints served by Alertmanager.
           If omitted, relevant URL components will be derived automatically.
@@ -104,11 +104,11 @@ in {
       '';
 
       serviceConfig = {
-        User = "${cfg.user}";
-        Group = "${cfg.group}";
+        User = cfg.user;
+        Group = cfg.group;
         Restart  = "always";
         PrivateTmp = true;
-        WorkingDirectory = /tmp;
+        WorkingDirectory = "/tmp";
       };
     };
   };


### PR DESCRIPTION
###### Motivation for this change

Get Prometheus Alertmanager running in NixOS
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [X] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md)
## \- [x] Tested in NixOS container
