### PR TITLE
prometheus: added default option values for relabel_config

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -300,13 +300,14 @@ let
       };
       regex = mkOption {
         type = types.str;
+        default = "(.*)";
         description = ''
           Regular expression against which the extracted value is matched.
         '';
       };
       replacement = mkOption {
         type = types.str;
-        default = "";
+        default = "$1";
         description = ''
           Replacement value against which a regex replace is performed if the
           regular expression matches.
@@ -314,6 +315,7 @@ let
       };
       action = mkOption {
         type = types.enum ["replace" "keep" "drop"];
+        default = "replace";
         description = ''
           Action to perform based on regex matching.
         '';


### PR DESCRIPTION
###### Motivation for this change

adding default option values to relabel_config as it is documented here:
https://prometheus.io/docs/operating/configuration/#%3Crelabel_config%3E
###### Things done
- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [x] NixOS
  - [ ] OS X
  - [x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
