### PR TITLE
bugfix: service name in the correct format

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/snmp-exporter.nix
+++ b/nixos/modules/services/monitoring/prometheus/snmp-exporter.nix
@@ -7,7 +7,7 @@ let
   mkConfigFile = pkgs.writeText "snmp.yml" (builtins.toJSON cfg.configuration);
 in {
   options = {
-    services.prometheus.snmp-exporter = {
+    services.prometheus.snmpExporter = {
       enable = mkEnableOption "prometheus snmp exporter";
 
       user = mkOption {


### PR DESCRIPTION
###### Motivation for this change

Deploying with nixops to virtualbox caused `error: attribute ‘snmpExporter’ missing, at /Users/hschaeidt/.nix-defexpr/channels/nixpkgs/nixos/modules/services/monitoring/prometheus/snmp-exporter.nix:6:9`even when not using prometheus.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
