### PR TITLE
babeld module: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -336,6 +336,7 @@
   ./services/networking/asterisk.nix
   ./services/networking/atftpd.nix
   ./services/networking/avahi-daemon.nix
+  ./services/networking/babeld.nix
   ./services/networking/bind.nix
   ./services/networking/autossh.nix
   ./services/networking/bird.nix

--- a/nixos/modules/services/networking/babeld.nix
+++ b/nixos/modules/services/networking/babeld.nix
@@ -90,8 +90,6 @@ in
 
   config = mkIf config.services.babeld.enable {
 
-    networking.firewall.allowedUDPPorts = [ 6696 ];
-
     systemd.services.babeld = {
       description = "Babel routing daemon";
       after = [ "network.target" ];

--- a/nixos/modules/services/networking/babeld.nix
+++ b/nixos/modules/services/networking/babeld.nix
@@ -1,0 +1,105 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.babeld;
+
+  babelToString = x: if builtins.typeOf x == "bool"
+                    then (if x then "true" else "false")
+                    else toString x;
+
+  paramsString = params:
+    (toString (map (name: "${name} ${babelToString (getAttr name params)}")
+                   (attrNames params)));
+
+  interfaceConfig = name:
+    let
+      interface = getAttr name cfg.interfaces;
+    in
+    "interface ${name} ${paramsString interface} \n";
+
+  configFile = with cfg; pkgs.writeText "babeld.conf"
+    ''
+      ${optionalString (cfg.interfaceDefaults != null) ("default " + (paramsString cfg.interfaceDefaults))}
+      ${toString (map interfaceConfig (attrNames cfg.interfaces))}
+      ${extraConfig}
+    '';
+
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    services.babeld = {
+
+      enable = mkOption {
+        default = false;
+        description = ''
+          Whether to run the babeld network routing daemon.
+        '';
+      };
+
+      interfaceDefaults = mkOption {
+        default = null;
+        description = ''
+          A set describing default parameters for babeld interfaces.
+          See `babeld(8)' for options.
+        '';
+        type = types.nullOr (types.attrsOf types.unspecified);
+        example =
+          {
+            wired = true;
+            "split-horizon" = true;
+          };
+      };
+
+      interfaces = mkOption {
+        default = {};
+        description = ''
+          A set describing babeld interfaces.
+          See `babeld(8)' for options.
+        '';
+        type = types.attrsOf (types.attrsOf types.unspecified);
+        example =
+          { enp0s2 =
+            { wired = true;
+              "hello-interval" = 5;
+              "split-horizon" = "auto";
+            };
+          };
+      };
+
+      extraConfig = mkOption {
+        default = "";
+        description = ''
+          Options that will be copied to babeld.conf.
+          See `babeld(8)' for details.
+        '';
+      };
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = mkIf config.services.babeld.enable {
+
+    networking.firewall.allowedUDPPorts = [ 6696 ];
+
+    systemd.services.babeld = {
+      description = "Babel routing daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.babeld ];
+      serviceConfig.ExecStart = "${pkgs.babeld}/bin/babeld -c ${configFile}";
+    };
+
+  };
+
+}

--- a/nixos/modules/services/networking/babeld.nix
+++ b/nixos/modules/services/networking/babeld.nix
@@ -48,7 +48,7 @@ in
         default = null;
         description = ''
           A set describing default parameters for babeld interfaces.
-          See `babeld(8)' for options.
+          See <citerefentry><refentrytitle>babeld</refentrytitle><manvolnum>8</manvolnum></citerefentry> for options.
         '';
         type = types.nullOr (types.attrsOf types.unspecified);
         example =
@@ -62,7 +62,7 @@ in
         default = {};
         description = ''
           A set describing babeld interfaces.
-          See `babeld(8)' for options.
+          See <citerefentry><refentrytitle>babeld</refentrytitle><manvolnum>8</manvolnum></citerefentry> for options.
         '';
         type = types.attrsOf (types.attrsOf types.unspecified);
         example =
@@ -78,7 +78,7 @@ in
         default = "";
         description = ''
           Options that will be copied to babeld.conf.
-          See `babeld(8)' for details.
+          See <citerefentry><refentrytitle>babeld</refentrytitle><manvolnum>8</manvolnum></citerefentry> for details.
         '';
       };
     };
@@ -96,7 +96,6 @@ in
       description = "Babel routing daemon";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.babeld ];
       serviceConfig.ExecStart = "${pkgs.babeld}/bin/babeld -c ${configFile}";
     };
 


### PR DESCRIPTION
###### Motivation for this change

Adding a module for babeld abstracts service generation and improves reusability.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

