### PR TITLE
jitsi-meet

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -377,6 +377,9 @@
   ./services/networking/i2p.nix
   ./services/networking/iodine.nix
   ./services/networking/ircd-hybrid/default.nix
+  ./services/networking/jitsi/jicofo.nix
+  ./services/networking/jitsi/jitsi-meet.nix
+  ./services/networking/jitsi/jitsi-videobridge.nix
   ./services/networking/kippo.nix
   ./services/networking/lambdabot.nix
   ./services/networking/libreswan.nix

--- a/nixos/modules/services/networking/jitsi/jicofo.nix
+++ b/nixos/modules/services/networking/jitsi/jicofo.nix
@@ -1,0 +1,129 @@
+{ config, pkgs, lib, ... }:
+
+with pkgs;
+with lib;
+
+let
+  cfg = config.services.jitsi.jicofo;
+in {
+  options = {
+    services.jitsi.jicofo = {
+      enable = mkEnableOption "JiCoFo";
+
+      user = mkOption {
+        type = types.str;
+        default = "jitsi";
+        description = ''
+          User name under which JiCoFo shall be run.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "nogroup";
+        description = ''
+          Group under which JiCoFo shall be run.
+        '';
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 5347;
+        description = ''
+          Sets the port of the XMPP server.
+        '';
+      };
+
+      host = mkOption {
+        type = types.nullOr types.str;
+        default = if cfg.domain != null then cfg.domain else "localhost";
+        description = ''
+          Sets the hostname of the XMPP server.
+        '';
+      };
+
+      secret = mkOption {
+        type = types.str;
+        description = ''
+          Sets the shared secret used to authenticate to the XMPP server.
+        '';
+      };
+
+      domain = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Sets the XMPP domain.
+        '';
+      };
+
+      subdomain = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Sets the sub-domain used to bind JVB XMPP component.
+        '';
+      };
+
+      userDomain = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Specifies the name of XMPP domain used by the focus user to login.
+        '';
+      };
+
+      userName = mkOption {
+        type = types.str;
+        default = "focus@${cfg.userDomain}";
+        description = ''
+          Specifies the username used by the focus XMPP user to login.
+        '';
+      };
+
+      userPassword = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Specifies the password used by focus XMPP user to login. If not provided then focus user will use anonymous authentication method.
+        '';
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Open port in firewall for incoming connections.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = optional cfg.openFirewall cfg.port;
+
+    systemd.services.jicofo = {
+      description = "JiCoFo";
+      path  = [ pkgs.jre ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      script = ''
+          ${pkgs.jicofo}/bin/jicofo \
+          --host=${cfg.host} \
+          --port=${toString cfg.port} \
+          --user_domain=${cfg.userDomain} \
+          --user_name=${cfg.userName} \
+          --secret=${cfg.secret} \
+          ${optionalString (cfg.subdomain != null) "--subdomain=${cfg.subdomain}"} ${optionalString (cfg.userPassword != null) "--user_password=${cfg.userPassword}"} ${optionalString (cfg.domain != null) "--domain=${cfg.domain}"}
+      '';
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        Restart  = "always";
+        PrivateTmp = true;
+        WorkingDirectory = "/tmp";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/jitsi/jitsi-meet.nix
+++ b/nixos/modules/services/networking/jitsi/jitsi-meet.nix
@@ -1,0 +1,84 @@
+{ config, pkgs, lib, ... }:
+
+with pkgs;
+with lib;
+
+let
+  cfg = config.services.jitsi.jitsi-meet;
+in {
+  options = rec {
+    services.jitsi.jitsi-meet = {
+      enable = mkEnableOption "jitsi-meet";
+
+      user = mkOption {
+        type = types.str;
+        default = "root";
+        description = ''
+          User name under which jitsi-meet shall be started.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "nogroup";
+        description = ''
+          Group under which jitsi-meet shall be started.
+        '';
+      };
+
+      hostname = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = ''
+          Sets the hostname.
+        '';
+      };
+
+      domain = mkOption {
+        type = types.str;
+        default = "localdomain";
+        description = ''
+          Sets the domain.
+        '';
+      };
+
+      configuration = mkOption {
+        type = types.str;
+        description = "config.js";
+        default = ''
+          var config = {
+            hosts: {
+              domain: '${cfg.hostname}.${cfg.domain}',
+              muc: 'conference.${cfg.hostname}.${cfg.domain}',
+              bridge: 'jitsi-videobridge.${cfg.hostname}.${cfg.domain}'
+            },
+            useNicks: false,
+            bosh: '//${cfg.hostname}.${cfg.domain}/http-bind',
+            desktopSharing: 'false'
+          };
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.jitsi-meet = {
+      description = "jitsi-meet";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      script = ''
+        ${pkgs.coreutils}/bin/mkdir -p /run/jitsi-meet
+        ${pkgs.coreutils}/bin/ln -sf ${pkgs.writeText "config.js" cfg.configuration} /run/jitsi-meet/config.js
+      '';
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        Type = "oneshot";
+        PrivateTmp = true;
+        WorkingDirectory = "/tmp";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/jitsi/jitsi-videobridge.nix
+++ b/nixos/modules/services/networking/jitsi/jitsi-videobridge.nix
@@ -1,0 +1,137 @@
+{ config, pkgs, lib, ... }:
+
+with pkgs;
+with lib;
+
+let
+  cfg = config.services.jitsi.jitsi-videobridge;
+in {
+  options = {
+    services.jitsi.jitsi-videobridge = {
+      enable = mkEnableOption "jitsi-videobridge";
+
+      user = mkOption {
+        type = types.str;
+        default = "jitsi";
+        description = ''
+          User name under which jitsi-videobridge shall be run.
+        '';
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "nogroup";
+        description = ''
+          Group under which jitsi-videobridge shall be run.
+        '';
+      };
+
+      port = mkOption {
+        type = types.int;
+        default = 5275;
+        description = ''
+          Sets the port of the XMPP server.
+        '';
+      };
+
+      minPort = mkOption {
+        type = types.int;
+        default = 10001;
+        description = ''
+          Sets the min port used for media.
+        '';
+      };
+
+      maxPort = mkOption {
+        type = types.int;
+        default = 20000;
+        description = ''
+          Sets the max port used for media.
+        '';
+      };
+
+      host = mkOption {
+        type = types.nullOr types.str;
+        default = if cfg.domain != null then cfg.domain else "localhost";
+        description = ''
+          Sets the hostname of the XMPP server.
+        '';
+      };
+
+      secret = mkOption {
+        type = types.str;
+        description = ''
+          Sets the shared secret used to authenticate to the XMPP server.
+        '';
+      };
+
+      domain = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Sets the XMPP domain.
+        '';
+      };
+
+      subdomain = mkOption {
+        type = types.str;
+        default = "jitsi-videobridge";
+        description = ''
+          Sets the sub-domain used to bind JVB XMPP component.
+        '';
+      };
+
+      apis = mkOption {
+        type = types.enum [ "xmpp" "rest" "xmpp,rest" ];
+        default = "xmpp";
+        description = ''
+          Where APIS is a comma separated list of APIs to enable.
+        '';
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Open port in firewall for incoming connections.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = optional cfg.openFirewall cfg.port;
+    networking.firewall.allowedUDPPortRanges = if cfg.openFirewall then [{ from = cfg.minPort; to = cfg.maxPort; }] else [];
+
+    systemd.services.jitsi-videobridge = {
+      description = "Jitsi Videobridge";
+      path  = [ pkgs.jre ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      preStart = ''
+        ${pkgs.coreutils}/bin/mkdir -p /home/${cfg.user}/.sip-communicator
+        ${pkgs.coreutils}/bin/echo "org.jitsi.impl.neomedia.transform.srtp.SRTPCryptoContext.checkReplay=false" > /home/${cfg.user}/.sip-communicator/sip-communicator.properties
+      '';
+
+      script = ''
+          ${pkgs.jitsi-videobridge}/bin/jitsi-videobridge \
+          --host=${cfg.host} \
+          --port=${toString cfg.port} \
+          --min-port=${toString cfg.minPort} \
+          --max-port=${toString cfg.maxPort} \
+          --secret=${cfg.secret} \
+          --apis=${cfg.apis} \
+          --subdomain=${cfg.subdomain} ${optionalString (cfg.domain != null) "--domain=${cfg.domain}"}
+      '';
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        Restart  = "always";
+        PrivateTmp = true;
+        WorkingDirectory = "/tmp";
+      };
+    };
+  };
+}

--- a/pkgs/servers/jitsi/jicofo.nix
+++ b/pkgs/servers/jitsi/jicofo.nix
@@ -1,0 +1,41 @@
+{ pkgs, stdenv, lib, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "jicofo-${rev}";
+  version = "1.0";
+  rev = "${version}-267-1";
+  arch = "amd64";
+
+  src = fetchurl {
+    url = "https://download.jitsi.org/jitsi/debian/jicofo_${rev}_${arch}.deb";
+    sha256 = "0b6wwav860x78n82knmhmf08jk36ygg65rdwfha7hdgkpjkdy6wr";
+  };
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  unpackCmd = "ar x $curSrc && tar -xvf data.tar.xz";
+  sourceRoot = "./";
+
+  installPhase = ''
+    mkdir -p $out/etc $out/bin
+    mv etc/jitsi $out/etc/
+    mv usr/share $out/
+    cd $out/share
+    ln -s jicofo java
+    cd $out/bin
+    ln -s ../share/jicofo/jicofo.sh jicofo
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "JItsi COnference FOcus is a server side focus component used in Jitsi Meet conferences.";
+    longDescription = ''
+      Conference focus is mandatory component of Jitsi Meet conferencing system next to the videobridge. It is responsible for managing media sessions between each of the participants and the videobridge. Whenever new conference is about to start an IQ is sent to the component to allocate new focus instance. After that special focus participant joins Multi User Chat room. It will be creating Jingle session between Jitsi videobridge and the participant. Although the session in terms of XMPP is between focus user and participant the media will flow between participant and the videobridge. That's because focus user will allocate Colibri channels on the bridge and use them as it's own Jingle transport.
+    '';
+    homepage = https://github.com/jitsi/jicofo;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ oida ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/jitsi/jitsi-meet.nix
+++ b/pkgs/servers/jitsi/jitsi-meet.nix
@@ -1,0 +1,42 @@
+{ pkgs, stdenv, lib, fetchurl, config }:
+
+stdenv.mkDerivation rec {
+  name = "jitsi-meet-${rev}";
+  version = "1.0.1073";
+  rev = "${version}-1";
+  arch = "all";
+
+  src = fetchurl {
+    url = "https://download.jitsi.org/jitsi/debian/jitsi-meet_${rev}_${arch}.deb";
+    sha256 = "1pl8qjn6n1x6nzjsfh4yngbd3a6r2j06v29w4n8shs7lll11l0wg";
+  };
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  unpackCmd = "ar x $curSrc && tar -xvf data.tar.xz";
+  sourceRoot = "./";
+
+  installPhase = ''
+    mkdir -p $out/etc $out/var
+    mv etc/jitsi $out/etc/
+    mv usr/share $out/
+    ln -s /run/jitsi-meet/config.js $out/share/jitsi-meet/config.js
+    cd $out/var
+    ln -s ../share/jitsi-meet www
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Jitsi Meet - Secure, Simple and Scalable Video Conferences https://jitsi.org/Projects/JitsiMeet";
+    longDescription = ''
+      Jitsi Meet is an open-source (Apache) WebRTC JavaScript application that uses Jitsi Videobridge to provide high quality, scalable video conferences. You can see Jitsi Meet in action here at the session #482 of the VoIP Users Conference.
+      You can also try it out yourself at https://meet.jit.si .
+      Jitsi Meet allows for very efficient collaboration. It allows users to stream their desktop or only some windows. It also supports shared document editing with Etherpad.
+    '';
+    homepage = https://github.com/jitsi/jitsi-meet;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ oida ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/servers/jitsi/jitsi-videobridge.nix
+++ b/pkgs/servers/jitsi/jitsi-videobridge.nix
@@ -1,0 +1,41 @@
+{ pkgs, stdenv, lib, fetchurl, makeWrapper, ... }:
+
+stdenv.mkDerivation rec {
+  name = "jitsi-videobridge-${rev}";
+  version = "751";
+  rev = "${version}-1";
+  arch = "amd64";
+
+  src = fetchurl {
+    url = "https://download.jitsi.org/jitsi/debian/jitsi-videobridge_${rev}_${arch}.deb";
+    sha256 = "0xy42xfpxmxhc2fmzz7k0k8l46xhjaz3yazn2pr4nksr91w6pkgz";
+  };
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  unpackCmd = "ar x $curSrc && tar -xvf data.tar.xz";
+  sourceRoot = "./";
+
+  installPhase = ''
+    mkdir -p $out/etc $out/bin
+    mv etc/jitsi $out/etc/
+    mv usr/share $out/
+    cd $out/share
+    ln -s jitsi-videobridge java
+    cd $out/bin
+    ln -s ../share/jitsi-videobridge/jvb.sh jitsi-videobridge
+  '';
+
+  doCheck = true;
+
+  meta = with stdenv.lib; {
+    description = "Jitsi Videobridge is an XMPP server component that allows for multiuser video communication.";
+    longDescription = ''
+      Jitsi Videobridge is an XMPP server component that allows for multiuser video communication. Unlike the expensive dedicated hardware videobridges, Jitsi Videobridge does not mix the video channels into a composite video stream, but only relays the received video channels to all call participants. Therefore, while it does need to run on a server with good network bandwidth, CPU horsepower is not that critical for performance.
+    '';
+    homepage = https://github.com/jitsi/jitsi-videobridge;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ oida ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13414,9 +13414,15 @@ in
 
   jedit = callPackage ../applications/editors/jedit { };
 
+  jicofo = callPackage ../servers/jitsi/jicofo.nix { };
+
   jigdo = callPackage ../applications/misc/jigdo { };
 
   jitsi = callPackage ../applications/networking/instant-messengers/jitsi { };
+
+  jitsi-meet = callPackage ../servers/jitsi/jitsi-meet.nix { };
+
+  jitsi-videobridge = callPackage ../servers/jitsi/jitsi-videobridge.nix { };
 
   joe = callPackage ../applications/editors/joe { };
 


### PR DESCRIPTION
###### Motivation for this change
Added pkgs and modules for jitsi-meet, Jitsi Conference Focus and Jitsi Videobridge.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
