### PR TITLE
qt56.qtbase: use mariadb built with openssl

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -67,6 +67,7 @@ let
         harfbuzz = pkgs.harfbuzz-icu;
         cups = if stdenv.isLinux then pkgs.cups else null;
         bison = pkgs.bison2; # error: too few arguments to function 'int yylex(...
+        mysql = pkgs.mariadb_openssl;
         openssl = pkgs.openssl_1_1_0;
         inherit developerBuild decryptSslTraffic;
       };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10292,6 +10292,13 @@ in
     boost = boost159;
   };
 
+  mariadb_openssl = callPackage ../servers/sql/mariadb {
+    inherit (darwin) cctools;
+    inherit (pkgs.darwin.apple_sdk.frameworks) CoreServices;
+    boost = boost159;
+    openssl = openssl_1_0_2;
+  };
+
   mongodb = callPackage ../servers/nosql/mongodb {
     sasl = cyrus_sasl;
     inherit (darwin.apple_sdk.frameworks) Security;


### PR DESCRIPTION
###### Motivation for this change

I want my qt applications to build again.

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---


Signed-off-by: Maximilian Güntner <code@klandest.in>