### PR TITLE
qt56.qtbase: build with openssl 1.0.2 + fixes

### DIFF
--- a/pkgs/development/libraries/qt-5/5.6/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/default.nix
@@ -67,7 +67,7 @@ let
         harfbuzz = pkgs.harfbuzz-icu;
         cups = if stdenv.isLinux then pkgs.cups else null;
         bison = pkgs.bison2; # error: too few arguments to function 'int yylex(...
-        openssl = pkgs.openssl_1_1_0;
+        openssl = pkgs.openssl_1_0_2;
         inherit developerBuild decryptSslTraffic;
       };
 

--- a/pkgs/development/libraries/qt-5/5.6/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-5/5.6/qtbase/default.nix
@@ -81,6 +81,7 @@ stdenv.mkDerivation {
   preConfigure = ''
     export LD_LIBRARY_PATH="$PWD/lib:$PWD/plugins/platforms:$LD_LIBRARY_PATH"
     export MAKEFLAGS=-j$NIX_BUILD_CORES
+    export OPENSSL_LIBS='-L${openssl.dev}/lib -lssl -lcrypto'
 
     configureFlags+="\
         -plugindir $out/lib/qt5/plugins \
@@ -179,7 +180,7 @@ stdenv.mkDerivation {
   ++ lib.optional mesaSupported mesa;
 
   buildInputs =
-    [ bison flex gperf ]
+    [ bison flex gperf openssl ]
     ++ lib.optional developerBuild gdb
     ++ lib.optional (cups != null) cups
     ++ lib.optional (mysql != null) mysql.lib


### PR DESCRIPTION
###### Motivation for this change

I want my qt applications to build again.

-- Actual fix of #18 

###### Things done

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
