### PR TITLE
libproxy: fix installation

### DIFF
--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, pkgconfig, cmake
-, dbus, networkmanager, webkitgtk216x, pcre }:
+, dbus, networkmanager, webkitgtk216x, pcre, python2, python3 }:
 
 stdenv.mkDerivation rec {
   name = "libproxy-${version}";
@@ -16,11 +16,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ pkgconfig cmake ];
 
-  buildInputs = [ dbus networkmanager webkitgtk216x pcre ];
+  buildInputs = [ dbus networkmanager webkitgtk216x pcre python2 python3 ];
 
   cmakeFlags = [
     "-DWITH_WEBKIT3=ON"
     "-DWITH_MOZJS=OFF"
+    "-DPYTHON2_SITEPKG_DIR=$(out)/${python2.sitePackages}"
+    "-DPYTHON3_SITEPKG_DIR=$(out)/${python3.sitePackages}"
   ];
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
###### Motivation for this change
installation failed after version upgrade

please check @fpletz :)
###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

