### PR TITLE
nettools: make more tools available

### DIFF
--- a/pkgs/os-specific/linux/net-tools/default.nix
+++ b/pkgs/os-specific/linux/net-tools/default.nix
@@ -13,7 +13,14 @@ stdenv.mkDerivation rec {
       cp ${./config.h} config.h
     '';
 
-  makeFlags = "BASEDIR=$(out) mandir=/share/man";
+  makeFlags = [
+    "BASEDIR=$(out)"
+    "mandir=/share/man"
+    "HAVE_ARP_TOOLS=1"
+    "HAVE_PLIP_TOOLS=1"
+    "HAVE_SERIAL_TOOLS=1"
+    "HAVE_HOSTNAME_TOOLS=1"
+  ];
 
   meta = {
     homepage = http://net-tools.sourceforge.net/;


### PR DESCRIPTION
because of the last version upgrade some binarys weren't available
anymore (e.g. hostname, on which quite a few packages depend)

###### Motivation for this change


###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

