### PR TITLE
modules sks-keyserver and pgpkeyserver-lite webgui

### DIFF
--- a/lib/maintainers.nix
+++ b/lib/maintainers.nix
@@ -88,6 +88,7 @@
   bstrik = "Berno Strik <dutchman55@gmx.com>";
   bzizou = "Bruno Bzeznik <Bruno@bzizou.net>";
   c0dehero = "CodeHero <codehero@nerdpol.ch>";
+  calbrecht = "Christian Albrecht <christian.albrecht@mayflower.de>";
   calrama = "Moritz Maxeiner <moritz@ucworks.org>";
   calvertvl = "Victor Calvert <calvertvl@gmail.com>";
   campadrenalin = "Philip Horger <campadrenalin@gmail.com>";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -565,6 +565,7 @@
   ./services/security/oauth2_proxy.nix
   ./services/security/physlock.nix
   ./services/security/shibboleth-sp.nix
+  ./services/security/sks.nix
   ./services/security/sshguard.nix
   ./services/security/tor.nix
   ./services/security/torify.nix
@@ -591,6 +592,7 @@
   ./services/web-apps/frab.nix
   ./services/web-apps/mattermost.nix
   ./services/web-apps/nixbot.nix
+  ./services/web-apps/pgpkeyserver-lite.nix
   ./services/web-apps/piwik.nix
   ./services/web-apps/privacyidea.nix
   ./services/web-apps/pump.io.nix

--- a/nixos/modules/services/security/sks.nix
+++ b/nixos/modules/services/security/sks.nix
@@ -1,0 +1,84 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.sks;
+
+  sksPkg = cfg.package;
+
+in
+
+{
+
+  options = {
+
+    services.sks = {
+
+      enable = mkEnableOption "sks";
+
+      package = mkOption {
+        default = pkgs.sks;
+        defaultText = "pkgs.sks";
+        type = types.package;
+        description = "
+          Which sks derivation to use.
+        ";
+      };
+
+      hkpAddress = mkOption {
+        default = [ "127.0.0.1" "::" ];
+        type = types.listOf types.str;
+        description = "
+          Wich ip addresses the sks-keyserver is listening on.
+        ";
+      };
+
+      hkpPort = mkOption {
+        default = 11371;
+        type = types.int;
+        description = "
+          Which port the sks-keyserver is listening on.
+        ";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    environment.systemPackages = [ sksPkg ];
+    
+    users.users.sks = {
+      createHome = true;
+      home = "/var/db/sks";
+      isSystemUser = true;
+      shell = "${pkgs.coreutils}/bin/true";
+    };
+
+    systemd.services = let
+      hkpAddress = "'" + (builtins.concatStringsSep " " cfg.hkpAddress) + "'" ;
+      hkpPort = builtins.toString cfg.hkpPort;
+      home = config.users.users.sks.home;
+      user = config.users.users.sks.name;
+    in {
+      sks-keyserver = {
+        wants = [ "sks-init.service" ];
+        after = [ "sks-init.service" ];
+        wantedBy = [ "multi-user.target" ];
+        preStart = ''
+          mkdir -p ${home}/dump
+          ${pkgs.sks}/bin/sks build ${home}/dump/*.gpg -n 10 -cache 100 || true #*/
+          ${pkgs.sks}/bin/sks cleandb || true
+          ${pkgs.sks}/bin/sks pbuild -cache 20 -ptree_cache 70 || true
+        '';
+        serviceConfig = {
+          WorkingDirectory = home;
+          User = user;
+          Restart = "always";
+          ExecStart = "${pkgs.sks}/bin/sks db -hkp_address ${hkpAddress} -hkp_port ${hkpPort}";
+        };
+      };
+    };
+  };
+}

--- a/nixos/modules/services/web-apps/pgpkeyserver-lite.nix
+++ b/nixos/modules/services/web-apps/pgpkeyserver-lite.nix
@@ -1,0 +1,76 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.pgpkeyserver-lite;
+  sksCfg = config.services.sks;
+
+  webPkg = cfg.package;
+
+in
+
+{
+
+  options = {
+
+    services.pgpkeyserver-lite = {
+
+      enable = mkEnableOption "pgpkeyserver-lite on a nginx vHost proxying to a gpg keyserver";
+
+      package = mkOption {
+        default = pkgs.pgpkeyserver-lite;
+        defaultText = "pkgs.pgpkeyserver-lite";
+        type = types.package;
+        description = "
+          Which webgui derivation to use.
+        ";
+      };
+
+      hostname = mkOption {
+        type = types.str;
+        description = "
+          Which hostname to set the vHost to that is proxying to sks.
+        ";
+      };     
+
+      hkpAddress = mkOption {
+        default = sksCfg.hkpAddress;
+        type = types.listOf types.str;
+        description = "
+          Wich ip address the sks-keyserver is listening on.
+        ";
+      };
+
+      hkpPort = mkOption {
+        default = sksCfg.hkpPort;
+        type = types.int;
+        description = "
+          Which port the sks-keyserver is listening on.
+        ";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    services.nginx.enable = true;
+
+    services.nginx.virtualHosts = let
+      hkpAddress = builtins.concatStringsSep " " cfg.hkpAddress;
+      hkpPort = builtins.toString cfg.hkpPort;
+    in {
+      "${cfg.hostname}" = {
+        root = webPkg;
+        locations = {
+          "/pks".extraConfig = ''
+            proxy_pass         http://${hkpAddress}:${hkpPort};
+            proxy_pass_header  Server;
+            add_header         Via "1.1 ${cfg.hostname}";
+          '';
+        };
+      };
+    };
+  };
+}

--- a/pkgs/servers/web-apps/pgpkeyserver-lite/default.nix
+++ b/pkgs/servers/web-apps/pgpkeyserver-lite/default.nix
@@ -1,0 +1,24 @@
+{ stdenv, fetchFromGitHub, lib } : 
+
+stdenv.mkDerivation rec {
+  name = "pgpkeyserver-lite-${version}";
+  version = "2017-07-18";
+
+  src = fetchFromGitHub {
+    owner = "mattrude";
+    repo = "pgpkeyserver-lite";
+    rev = "a038cb7";
+    sha256 = "12pn92pcpv38b2gmamppn9yzdn7x52pgxnzpal22gqsxwimhs2rx";
+  };
+
+  installPhase = ''
+    mkdir -p $out
+    cp -R 404.html assets favicon.ico index.html robots.txt $out
+  '';
+
+  meta = {
+    homepage = https://github.com/mattrude/pgpkeyserver-lite;
+    description = "A lightweight static front-end for a sks keyserver.";
+    license = lib.licenses.gpl3;
+  };
+}

--- a/pkgs/servers/web-apps/pgpkeyserver-lite/default.nix
+++ b/pkgs/servers/web-apps/pgpkeyserver-lite/default.nix
@@ -20,5 +20,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/mattrude/pgpkeyserver-lite;
     description = "A lightweight static front-end for a sks keyserver.";
     license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.calbrecht ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8095,6 +8095,8 @@ with pkgs;
 
   pgpdump = callPackage ../tools/security/pgpdump { };
 
+  pgpkeyserver-lite = callPackage ../servers/web-apps/pgpkeyserver-lite {};
+
   gpgstats = callPackage ../tools/security/gpgstats { };
 
   gpshell = callPackage ../development/tools/misc/gpshell { };


### PR DESCRIPTION
runs the sks keyserver with optional nginx proxy for webgui.

###### Motivation for this change

have a reliable keyserver service with webgui

###### Things done

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

