### PR TITLE
borgbackup: add postStart option

### DIFF
--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -13,6 +13,7 @@ let
       "BORG_PASSPHRASE" = jobcfg.passphrase or "";
     };
     preStart = jobcfg.preBackup;
+    postStart = jobcfg.postBackup;
     script = ''
       echo Running borg create
       ${pkgs.borgbackup}/bin/borg create -v \
@@ -204,6 +205,12 @@ in
             type = types.lines;
             default = "";
             description = "Script to execute before the backup job.";
+          };
+
+          postBackup = mkOption {
+            type = types.lines;
+            default = "";
+            description = "Script to execute after the backup job.";
           };
 
           interval = mkOption {


### PR DESCRIPTION
###### Motivation for this change

when backing up to an external medium (e.g. usb stick),
mounting / unmounting it before backup makes rotation
easy.

Example:
```nix
  jobs = {
    main = {
      repository = "/mnt/backup/borg";
      paths = [ "/mnt/data/fnord" ];
      passphrase = "foobar";
      preBackup = ''
        #!/usr/bin/env bash
        mkdir -p /mnt/backup
        chown borg /mnt/backup
        ${pkgs.utillinux}/bin/mount LABEL=backup /mnt/backup
      '';
      postBackup = ''
        #!/usr/bin/env bash
        sync
        ${pkgs.utillinux}/bin/umount /mnt/backup
      '';
    };
```


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

