### PR TITLE
perl-gtk2: fix build

### DIFF
--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, pkgconfig, libXft, cairo, harfbuzz
+{ stdenv, fetchurl, fetchpatch, pkgconfig, libXft, cairo, harfbuzz
 , libintlOrEmpty, gobjectIntrospection, darwin
 }:
 
@@ -15,6 +15,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/pango/${ver_maj}/${name}.tar.xz";
     sha256 = "9faea6535312fe4436b93047cf7a04af544eb52a079179bd3a33821aacce7e16";
   };
+
+  patches = [
+    # https://bugzilla.gnome.org/show_bug.cgi?id=785978#c9
+    (fetchpatch rec {
+      name = "pango-fix-gtk2-test-failures.patch";
+      url = "https://bug785978.bugzilla-attachments.gnome.org/attachment.cgi?id=357690&action=diff&collapsed=&context=patch&format=raw&headers=1";
+      sha256 = "055m2dllfr5pgw6bci72snw38f4hsyw1x7flj188c965ild8lq3a";
+    })
+  ];
 
   outputs = [ "bin" "dev" "out" "devdoc" ];
 


### PR DESCRIPTION
###### Motivation for this change
This [pango bug](https://bugzilla.gnome.org/show_bug.cgi?id=785978#c9) caused the tests of perl-gtk2 to fail.
fixes https://hydra.mayflower.de/build/47339

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

