### PR TITLE
prometheus[2] service: add scrapeConfigs.honor_labels option

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/2.nix
+++ b/nixos/modules/services/monitoring/prometheus/2.nix
@@ -75,6 +75,14 @@ let
 
   promTypes.scrape_config = types.submodule {
     options = {
+      honor_labels = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = ''
+          Do not overwrite any labels exposed by the source server when
+          using federation.
+        '';
+      };
       job_name = mkOption {
         type = types.str;
         description = ''

--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -70,6 +70,14 @@ let
 
   promTypes.scrape_config = types.submodule {
     options = {
+      honor_labels = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = ''
+          Do not overwrite any labels exposed by the source server when
+          using federation.
+        '';
+      };
       job_name = mkOption {
         type = types.str;
         description = ''


### PR DESCRIPTION
###### Motivation for this change
add the scrape_config option `honor_labels` for monitoring setups that use federation

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

