### PR TITLE
privacyidea: add python packages to runtime environment

### DIFF
--- a/nixos/modules/services/web-apps/privacyidea.nix
+++ b/nixos/modules/services/web-apps/privacyidea.nix
@@ -168,7 +168,8 @@ in
     systemd.services.privacyidea = let
       uwsgi = pkgs.uwsgi.override { plugins = [ "python2" ]; };
       penv = uwsgi.python2.buildEnv.override {
-        extraLibs = [ pkgs.privacyidea ];
+        extraLibs = [ pkgs.privacyidea ] ++ (with pkgs.pythonPackages; [
+          pyopenssl cryptography cffi ]);
       };
       piuwsgi = pkgs.writeText "uwsgi.json" (builtins.toJSON {
         uwsgi = {


### PR DESCRIPTION
###### Motivation for this change

Adds runtime dependencies to privacyidea service.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

