### PR TITLE
Add libxl and php_excel

### DIFF
--- a/pkgs/development/libraries/libxl/default.nix
+++ b/pkgs/development/libraries/libxl/default.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "libxl";
+  version = "3.8.1";
+
+  src = fetchurl {
+    url = "http://www.libxl.com/download/${name}-lin-${version}.tar.gz";
+    sha256 = "1zdbahhyhr70s8hygwp43j9z4zmglyrr782hkcm1078yvkr2f2fm";
+  };
+
+  phases = [ "unpackPhase" "installPhase" "fixupPhase" ];
+
+  installPhase = ''
+    mkdir $out
+    cp -rva include_c include_cpp license.txt $out/
+    cp -rva lib64 $out/lib
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A lbrary for parsing excel files";
+    license     = licenses.unfree;
+    platforms   = platforms.linux;
+    maintainers = with maintainers; [  ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19692,4 +19692,6 @@ with pkgs;
 
     macOSSierraShared = callPackage ../test/macos-sierra-shared {};
   };
+
+  libxl = callPackage ../development/libraries/libxl {};
 }

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -73,6 +73,21 @@ let
     ];
   };
 
+  php_excel = assert isPhp7; buildPecl rec {
+    name = "php_excel";
+    version = "1.0.2";
+    phpVersion = "php7";
+
+    buildInputs = [ pkgs.libxl ];
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/iliaal/${name}/releases/download/Excel-1.0.2-PHP7/excel-${version}-${phpVersion}.tgz";
+      sha256 = "0dpvih9gpiyh1ml22zi7hi6kslkilzby00z1p8x248idylldzs2n";
+    };
+
+    configureFlags = [ "--with-excel" "--with-libxl-incdir=${pkgs.libxl}/include_c" "--with-libxl-libdir=${pkgs.libxl}/lib" ];
+  };
+
   igbinary = buildPecl {
     name = "igbinary-2.0.4";
 


### PR DESCRIPTION
###### Motivation for this change

Adds unfree package libxl as well as php_excel (not to be confused with PHPExcel, therefore the name in the code).

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

