### PR TITLE
update prometheus exporters

### DIFF
--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -25,6 +25,7 @@ let
     DATABASE_USER = cfg.database.user;
     DATABASE_PASSWORD = cfg.database.password;
     DATABASE_PATH = cfg.database.path;
+    DATABASE_CONN_MAX_LIFETIME = cfg.database.connMaxLifetime;
 
     SECURITY_ADMIN_USER = cfg.security.adminUser;
     SECURITY_ADMIN_PASSWORD = cfg.security.adminPassword;
@@ -143,6 +144,15 @@ in {
         default = "${cfg.dataDir}/data/grafana.db";
         type = types.path;
       };
+
+      connMaxLifetime = mkOption {
+        description = ''
+          Sets the maximum amount of time (in seconds) a connection may be reused.
+          For MySQL this setting should be shorter than the `wait_timeout' variable.
+        '';
+        default = 14400;
+        type = types.int;
+      };
     };
 
     security = {
@@ -241,7 +251,9 @@ in {
       description = "Grafana Service Daemon";
       wantedBy = ["multi-user.target"];
       after = ["networking.target"];
-      environment = mapAttrs' (n: v: nameValuePair "GF_${n}" (toString v)) envOptions;
+      environment = {
+        QT_QPA_PLATFORM = "offscreen";
+      } // mapAttrs' (n: v: nameValuePair "GF_${n}" (toString v)) envOptions;
       serviceConfig = {
         ExecStart = "${cfg.package.bin}/bin/grafana-server -homepath ${cfg.dataDir}";
         WorkingDirectory = cfg.dataDir;

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -1,7 +1,7 @@
 { lib, buildGoPackage, fetchurl, fetchFromGitHub, phantomjs2 }:
 
 buildGoPackage rec {
-  version = "5.0.0";
+  version = "5.0.3";
   name = "grafana-${version}";
   goPackagePath = "github.com/grafana/grafana";
 
@@ -9,12 +9,12 @@ buildGoPackage rec {
     rev = "v${version}";
     owner = "grafana";
     repo = "grafana";
-    sha256 = "1clkvi651wc4zx9bql5iwwnjgwgrj34dirs7ypi6rdgxissp89p9";
+    sha256 = "0508dvkanrfrvdnddjsaz8qm3qbgavznia5hqr8zx3qvq4789hj2";
   };
 
   srcStatic = fetchurl {
     url = "https://grafana-releases.s3.amazonaws.com/release/grafana-${version}.linux-x64.tar.gz";
-    sha256 = "1n2l5ybscc0g1npsa648wjwwb4qrj3f549nf0y6wsifp5k051lhd";
+    sha256 = "0dzb93vx72sm6iri6c96k3a15zn8mp26pd2r78m6k3nhg8rsrqmm";
   };
 
   preBuild = "export GOPATH=$GOPATH:$NIX_BUILD_TOP/go/src/${goPackagePath}/Godeps/_workspace";

--- a/pkgs/servers/monitoring/prometheus/dovecot-exporter-deps.nix
+++ b/pkgs/servers/monitoring/prometheus/dovecot-exporter-deps.nix
@@ -32,8 +32,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/golang/protobuf";
-      rev = "c65a0412e71e8b9b3bfd22925720d23c0f054237";
-      sha256 = "1ch3czyzq5abl6zm1l0dfsi09xj43ql9jcbmbhfhxz954pw03v3v";
+      rev = "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175";
+      sha256 = "1pyli3dcagi7jzpiazph4fhkz7a3z4bhd25nwbb7g0iy69b8z1g4";
     };
   }
   {
@@ -50,8 +50,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/client_golang";
-      rev = "06bc6e01f4baf4ee783ffcd23abfcb0b0f9dfada";
-      sha256 = "0dvv21214sn702kc25y5l0gd9d11358976d3w31fgwx7456mjx26";
+      rev = "c3324c1198cf3374996e9d3098edd46a6b55afc9";
+      sha256 = "19qcz5bpzj5kqyhmbq5kxr8nrqqlszazzq6w0wldis1yk1wwww00";
     };
   }
   {
@@ -68,8 +68,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/common";
-      rev = "89604d197083d4781071d3c65855d24ecfb0a563";
-      sha256 = "169rdlaf2mk9z4fydz7ajmngyhmf3q1lk96yhvx46bn986x5xkyn";
+      rev = "e4aa40a9169a88835b849a6efb71e05dc04b88f0";
+      sha256 = "0m1n616d694jca0qjwjn5ci7scfgm2jpi94dhi356arm9lhda4jc";
     };
   }
   {
@@ -77,8 +77,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/procfs";
-      rev = "cb4147076ac75738c9a7d279075a253c0cc5acbd";
-      sha256 = "0zhlrik0f9q1lj6cisgnxgbz4darbcix52hm5abi24l2ahchf5ca";
+      rev = "54d17b57dd7d4a3aa092476596b3f8a933bde349";
+      sha256 = "1b5218hi6k9i637k6xc7ynpll577zbnrhjm9jr2iczy3j0rr4rvr";
     };
   }
   {

--- a/pkgs/servers/monitoring/prometheus/dovecot-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/dovecot-exporter.nix
@@ -1,17 +1,16 @@
 { stdenv, buildGoPackage, fetchFromGitHub }:
 
 buildGoPackage rec {
-  name = "dovecot_exporter-unstable-${version}";
-  version = "2018-01-18";
-  rev = "4e831356533e2321031df73ebd25dd55dbd8d385";
+  name = "dovecot_exporter-${version}";
+  version = "0.1.1";
 
   goPackagePath = "github.com/kumina/dovecot_exporter";
 
   src = fetchFromGitHub {
     owner = "kumina";
     repo = "dovecot_exporter";
-    inherit rev;
-    sha256 = "0iky1i7m5mlknkhlpsxpjgigssg5m02nx5y7i4biddkqilfic74n";
+    rev = version;
+    sha256 = "0i7nfgkb5jqdbgr16i29jdsvh69dx9qgn6nazpw78k0lgy7mpidn";
   };
 
   goDeps = ./dovecot-exporter-deps.nix;

--- a/pkgs/servers/monitoring/prometheus/postfix-exporter-deps.nix
+++ b/pkgs/servers/monitoring/prometheus/postfix-exporter-deps.nix
@@ -10,12 +10,30 @@
     };
   }
   {
+    goPackagePath = "github.com/coreos/go-systemd";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/go-systemd";
+      rev = "127658326aaff7892c7d60c29657c6e6c440ad7e";
+      sha256 = "1qckr877q9yigkw73l76fwrx6y4d9hv5057xa6y7qcn8d33jdpjm";
+    };
+  }
+  {
+    goPackagePath = "github.com/coreos/pkg";
+    fetch = {
+      type = "git";
+      url = "https://github.com/coreos/pkg";
+      rev = "97fdf19511ea361ae1c100dd393cc47f8dcfa1e1";
+      sha256 = "1srn87wih25l09f75483hnxsr8fc6rq3bk7w1x8125ym39p6mg21";
+    };
+  }
+  {
     goPackagePath = "github.com/golang/protobuf";
     fetch = {
       type = "git";
       url = "https://github.com/golang/protobuf";
-      rev = "c65a0412e71e8b9b3bfd22925720d23c0f054237";
-      sha256 = "1ch3czyzq5abl6zm1l0dfsi09xj43ql9jcbmbhfhxz954pw03v3v";
+      rev = "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175";
+      sha256 = "1pyli3dcagi7jzpiazph4fhkz7a3z4bhd25nwbb7g0iy69b8z1g4";
     };
   }
   {
@@ -32,8 +50,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/client_golang";
-      rev = "06bc6e01f4baf4ee783ffcd23abfcb0b0f9dfada";
-      sha256 = "0dvv21214sn702kc25y5l0gd9d11358976d3w31fgwx7456mjx26";
+      rev = "c3324c1198cf3374996e9d3098edd46a6b55afc9";
+      sha256 = "19qcz5bpzj5kqyhmbq5kxr8nrqqlszazzq6w0wldis1yk1wwww00";
     };
   }
   {
@@ -50,8 +68,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/common";
-      rev = "89604d197083d4781071d3c65855d24ecfb0a563";
-      sha256 = "169rdlaf2mk9z4fydz7ajmngyhmf3q1lk96yhvx46bn986x5xkyn";
+      rev = "e4aa40a9169a88835b849a6efb71e05dc04b88f0";
+      sha256 = "0m1n616d694jca0qjwjn5ci7scfgm2jpi94dhi356arm9lhda4jc";
     };
   }
   {
@@ -59,8 +77,8 @@
     fetch = {
       type = "git";
       url = "https://github.com/prometheus/procfs";
-      rev = "cb4147076ac75738c9a7d279075a253c0cc5acbd";
-      sha256 = "0zhlrik0f9q1lj6cisgnxgbz4darbcix52hm5abi24l2ahchf5ca";
+      rev = "54d17b57dd7d4a3aa092476596b3f8a933bde349";
+      sha256 = "1b5218hi6k9i637k6xc7ynpll577zbnrhjm9jr2iczy3j0rr4rvr";
     };
   }
 ]

--- a/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
@@ -1,20 +1,28 @@
-{ stdenv, buildGoPackage, fetchFromGitHub }:
+{ stdenv, buildGoPackage, fetchFromGitHub, systemd, makeWrapper }:
 
 buildGoPackage rec {
-  name = "postfix_exporter-unstable-${version}";
-  version = "2017-06-01";
-  rev = "a8b4bed735a03f234fcfffba85302f51025e6b1d";
+  name = "postfix_exporter-${version}";
+  version = "0.1.0";
 
   goPackagePath = "github.com/kumina/postfix_exporter";
 
   src = fetchFromGitHub {
     owner = "kumina";
     repo = "postfix_exporter";
-    inherit rev;
-    sha256 = "0rxvjpyjcvr1y8k8skq5f1bnl0mpgvaa04dn8c44v7afqnv78riy";
+    rev = version;
+    sha256 = "1hv8d9ik49rnxlc9mlfx9bqq8rjc4zk3d3jk71kl46wajkjlsy8i";
   };
 
+  patches = [ ./postfix-exporter_systemd-journal.patch ];
+
+  buildInputs = [ systemd makeWrapper ];
+
   goDeps = ./postfix-exporter-deps.nix;
+
+  postInstall = ''
+    wrapProgram $bin/bin/postfix_exporter \
+      --prefix LD_LIBRARY_PATH : "${systemd.lib}/lib"
+  '';
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/servers/monitoring/prometheus/postfix-exporter_systemd-journal.patch
+++ b/pkgs/servers/monitoring/prometheus/postfix-exporter_systemd-journal.patch
@@ -1,0 +1,13 @@
+--- a/postfix_exporter.go
++++ b/postfix_exporter.go
+@@ -409,6 +409,10 @@ func (e *PostfixExporter) CollectLogfileFromJournal() error {
+ 	e.journal.Lock()
+ 	defer e.journal.Unlock()
+ 
++	r := e.journal.Wait(time.Duration(1) * time.Second)
++	if r < 0 {
++		log.Print("error while waiting for journal!")
++	}
+ 	for {
+ 		m, c, err := e.journal.NextMessage()
+ 		if err != nil {


### PR DESCRIPTION
###### Things done
* cherry-picked grafana update from upstream
* prometheus-postfix-exporter: 2017-06-01 -> 0.1.0
  added a patch to symptomatically fix an issue with the exporter where metrics are not updated after a while
* prometheus-dovecot-exporter: 2018-01-18 -> 0.1.1 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] Linux
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

