### PR TITLE
mailman: fix runtime issue with missing python modules

### DIFF
--- a/pkgs/servers/mail/mailman/default.nix
+++ b/pkgs/servers/mail/mailman/default.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitLab, python3 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonPackage rec {
   name = "mailman-${version}";
   version = "3.1.1";
 

--- a/pkgs/servers/mail/mailman/hyperkitty.nix
+++ b/pkgs/servers/mail/mailman/hyperkitty.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitLab, python3 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonPackage rec {
   name = "hyperkitty-${version}";
   version = "1.1.4";
 

--- a/pkgs/servers/mail/mailman/postorius.nix
+++ b/pkgs/servers/mail/mailman/postorius.nix
@@ -1,6 +1,6 @@
 { stdenv, fetchFromGitLab, fetchpatch, python3 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonPackage rec {
   name = "postorius-${version}";
   version = "1.1.1";
 


### PR DESCRIPTION
services failed because modules were missing from the python site-packages