### PR TITLE
oxidized: remove current temperature from x-series switch configs

### DIFF
--- a/pkgs/tools/admin/oxidized/temporary-x-series.patch
+++ b/pkgs/tools/admin/oxidized/temporary-x-series.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/oxidized/model/powerconnect.rb b/lib/oxidized/model/powerconnect.rb
-index f602a36..3f3a0f9 100644
+index f602a36..3bac2d1 100644
 --- a/lib/oxidized/model/powerconnect.rb
 +++ b/lib/oxidized/model/powerconnect.rb
 @@ -4,7 +4,7 @@ class PowerConnect < Oxidized::Model
@@ -11,3 +11,12 @@ index f602a36..3f3a0f9 100644
       send ' '
       data.sub re, ''
    end
+@@ -60,7 +60,7 @@ class PowerConnect < Oxidized::Model
+     skip_blocks = 0
+     cfg.each_line do |line|
+       # If this is a stackable switch we should skip this block of information
+-      if (line.match /Up\sTime|Temperature|Power Suppl(ies|y)|Fans/i and @stackable == true)
++      if (line.match /Up\sTime|Temperature|Power Suppl(ies|y)|Fans/i)
+         skip_blocks = 1
+         # Some switches have another empty line. This is identified by this line having a colon
+         skip_blocks = 2 if line.match /:/


### PR DESCRIPTION
###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---