### PR TITLE
nixos/prometheus-postfix-exporter: use systemd-journal group

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/postfix.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/postfix.nix
@@ -71,6 +71,7 @@ in
   };
   serviceOpts = {
     serviceConfig = {
+      SupplementaryGroups = optionalString cfg.systemd.enable "systemd-journal";
       ExecStart = ''
         ${pkgs.prometheus-postfix-exporter}/bin/postfix_exporter \
           --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \


### PR DESCRIPTION
This adds the exporter service to the group `systemd-journal` when
`services.prometheus.exporters.postfix.systemd.enable` is true, so that
it is able to read from the journal.