### PR TITLE
update/extend json-exporter & add rspamd-exporter

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -27,6 +27,7 @@ let
     nginx    = import ./exporters/nginx.nix    { inherit config lib pkgs; };
     node     = import ./exporters/node.nix     { inherit config lib pkgs; };
     postfix  = import ./exporters/postfix.nix  { inherit config lib pkgs; };
+    rspamd   = import ./exporters/rspamd.nix   { inherit config lib pkgs; };
     snmp     = import ./exporters/snmp.nix     { inherit config lib pkgs; };
     unifi    = import ./exporters/unifi.nix    { inherit config lib pkgs; };
     varnish  = import ./exporters/varnish.nix  { inherit config lib pkgs; };
@@ -159,11 +160,13 @@ in
       '';
     }];
   }] ++ [(mkIf config.services.minio.enable {
-    services.prometheus.exporters.minio.minioAddress  = mkDefault "http://localhost:9000";
+    services.prometheus.exporters.minio.minioAddress = mkDefault "http://localhost:9000";
     services.prometheus.exporters.minio.minioAccessKey = mkDefault config.services.minio.accessKey;
     services.prometheus.exporters.minio.minioAccessSecret = mkDefault config.services.minio.secretKey;
   })] ++ [(mkIf config.services.postfix.enable {
     services.prometheus.exporters.postfix.group = mkDefault config.services.postfix.setgidGroup;
+  })] ++ [(mkIf config.services.rspamd.enable {
+    services.prometheus.exporters.rspamd.url = mkDefault "http://localhost:11334/stat";
   })] ++ (mapAttrsToList (name: conf:
     mkExporterConf {
       inherit name;

--- a/nixos/modules/services/monitoring/prometheus/exporters/rspamd.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/rspamd.nix
@@ -1,0 +1,99 @@
+{ config, lib, pkgs }:
+
+with lib;
+
+let
+  cfg = config.services.prometheus.exporters.rspamd;
+
+  prettyJSON = conf:
+    pkgs.runCommand "rspamd-exporter-config.yml" { } ''
+      echo '${builtins.toJSON conf}' | ${pkgs.jq}/bin/jq '.' > $out
+    '';
+
+  generateConfig = extraLabels: (map (path: {
+    name = "rspamd_${replaceStrings [ "." " " ] [ "_" "_" ] path}";
+    path = "$.${path}";
+    labels = {
+      host = mkDefault config.networking.hostName;
+    } // extraLabels;
+  }) [
+    "actions.'add header'"
+    "actions.'no action'"
+    "actions.'rewrite subject'"
+    "actions.'soft reject'"
+    "actions.greylist"
+    "actions.reject"
+    "bytes_allocated"
+    "chunks_allocated"
+    "chunks_freed"
+    "chunks_oversized"
+    "connections"
+    "control_connections"
+    "ham_count"
+    "learned"
+    "pools_allocated"
+    "pools_freed"
+    "read_only"
+    "scanned"
+    "shared_chunks_allocated"
+    "spam_count"
+    "total_learns"
+  ]) ++ [{
+    name = "rspamd_statfiles";
+    type = "object";
+    path = "$.statfiles[*]";
+    labels = {
+      symbol = "$.symbol";
+      type = "$.type";
+    } // extraLabels;
+    values = {
+      revision = "$.revision";
+      size = "$.size";
+      total = "$.total";
+      used = "$.used";
+      languages = "$.languages";
+      users = "$.users";
+    };
+  }];
+in
+{
+  port = 7980;
+  extraOpts = {
+    listenAddress = {}; # not used
+
+    url = mkOption {
+      type = types.str;
+      description = ''
+        URL to the rspamd metrics endpoint.
+        Defaults to http://localhost:11334/stat when
+        <option>services.rspamd.enable</option> is true.
+      '';
+    };
+
+    extraLabels = mkOption {
+      type = types.attrsOf types.str;
+      default = {
+        host = config.networking.hostName;
+      };
+      defaultText = "{ host = config.networking.hostName; }";
+      example = literalExample ''
+        {
+          host = config.networking.hostName;
+          environment = "staging";
+        }
+      '';
+      description = "Set of labels added to each metric.";
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      DynamicUser = true;
+      ExecStart = ''
+        ${pkgs.prometheus-json-exporter}/bin/prometheus-json-exporter \
+          --port ${toString cfg.port} \
+          ${cfg.url} ${prettyJSON (generateConfig cfg.extraLabels)} \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/pkgs/servers/monitoring/prometheus/json-exporter-bool-support.patch
+++ b/pkgs/servers/monitoring/prometheus/json-exporter-bool-support.patch
@@ -1,0 +1,25 @@
+diff --git a/jsonexporter/scraper.go b/jsonexporter/scraper.go
+index 89e2157..d112c0b 100644
+--- a/jsonexporter/scraper.go
++++ b/jsonexporter/scraper.go
+@@ -67,6 +67,7 @@ func (vs *ValueScraper) Scrape(data []byte, reg *harness.MetricRegistry) error {
+ 		isFirst = false
+ 
+ 		var value float64
++		var boolValue bool
+ 		var err error
+ 		switch result.Type {
+ 		case jsonpath.JsonNumber:
+@@ -76,6 +77,12 @@ func (vs *ValueScraper) Scrape(data []byte, reg *harness.MetricRegistry) error {
+ 			value, err = vs.parseValue(result.Value[1 : len(result.Value)-1])
+ 		case jsonpath.JsonNull:
+ 			value = math.NaN()
++		case jsonpath.JsonBool:
++			if boolValue, err = strconv.ParseBool(string(result.Value)); boolValue {
++				value = 1
++			} else {
++				value = 0
++			}
+ 		default:
+ 			log.Warnf("skipping not numerical result;path:<%s>,value:<%s>",
+ 				vs.valueJsonPath, result.Value)

--- a/pkgs/servers/monitoring/prometheus/json-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/json-exporter.nix
@@ -16,6 +16,8 @@ buildGoPackage rec {
 
   goDeps = ./json-exporter_deps.nix;
 
+  patches = [ ./json-exporter-bool-support.patch ];
+
   meta = {
     description = "A prometheus exporter which scrapes remote JSON by JSONPath";
     homepage = https://github.com/kawamuray/prometheus-json-exporter;

--- a/pkgs/servers/monitoring/prometheus/json-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/json-exporter.nix
@@ -3,16 +3,15 @@
 
 buildGoPackage rec {
   name = "prometheus-json-exporter-${version}";
-  version = "unstable-2016-09-13";
-  rev = "d45e5ebdb08cb734ad7a8683966032af1d91a76c";
+  version = "unstable-2017-10-06";
 
   goPackagePath = "github.com/kawamuray/prometheus-json-exporter";
 
   src = fetchFromGitHub {
-    inherit rev;
     owner = "kawamuray";
     repo = "prometheus-json-exporter";
-    sha256 = "0v3as7gakdqpsir97byknsrqxxxkq66hp23j4cscs45hsdb24pi9";
+    rev = "51e3dc02a30ab818bb73e5c98c3853231c2dbb5f";
+    sha256 = "1v1p4zcqnb3d3rm55r695ydn61h6gz95f55cpa22hzw18dasahdh";
   };
 
   goDeps = ./json-exporter_deps.nix;


### PR DESCRIPTION
This bumps the `prometheus-json-exporter` to the latest version and adds a temporary patch for bool-parsing support.
It also adds a rspamd-exporter module, which is based on the `prometheus-json-exporter`. It provides the necessary config for the exporter to scrape all available rspamd metrics.