### PR TITLE
oxidized: add patch to exclude tplink timestamp

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -279,6 +279,16 @@ in
     buildInputs = [ curl libxml2 ];
   };
 
+  oxidized = attrs: rec {
+    tplinkPatch = (fetchpatch {
+      url = https://patch-diff.githubusercontent.com/raw/ytti/oxidized/pull/1443.diff;
+      sha256 = "09dyf1hnxgdxfkh9l6y63qmm1ds5wgb2d52vvrwwc0s4gl0b1yad";
+    });
+    postInstall = ''
+      patch -p1 -d $(cat $out/nix-support/gem-meta/install-path) -i ${tplinkPatch}
+    '';
+  };
+
   pango = attrs: {
     nativeBuildInputs = [ pkgconfig ];
     buildInputs = [ gtk2 xorg.libXdmcp pcre xorg.libpthreadstubs ];


### PR DESCRIPTION
This adds a patch to oxidized so that the current system time stamp is excluded from tp-link configs.