### PR TITLE
privacyidea-ldap-proxy experimental py3k support

### DIFF
--- a/nixos/modules/services/security/privacyidea.nix
+++ b/nixos/modules/services/security/privacyidea.nix
@@ -272,7 +272,7 @@ in
     (mkIf cfg.ldap-proxy.enable {
 
       systemd.services.privacyidea-ldap-proxy = let
-        ldap-proxy-env = pkgs.python2.withPackages (ps: [ ps.privacyidea-ldap-proxy ]);
+        ldap-proxy-env = python.withPackages (ps: [ ps.privacyidea-ldap-proxy ]);
       in {
         description = "privacyIDEA LDAP proxy";
         wantedBy = [ "multi-user.target" ];

--- a/pkgs/development/python-modules/ldaptor/default.nix
+++ b/pkgs/development/python-modules/ldaptor/default.nix
@@ -13,21 +13,16 @@
 
 buildPythonPackage rec {
   pname = "ldaptor";
-  version = "19.1.0";
+  version = "21.2.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "64c7b870c77e34e4f5f9cfdf330b9702e89b4dd0f64275704f86c1468312c755";
+    sha256 = "0n53czn5pyh8923y282spdb7xc8c9rhn0n43bczanjjx6wcynjcc";
   };
 
   propagatedBuildInputs = [
     twisted passlib pycrypto pyopenssl pyparsing service-identity zope_interface
   ];
-
-  disabled = isPy3k;
-
-  # TypeError: None is neither bytes nor unicode
-  doCheck = false;
 
   meta = {
     description = "A Pure-Python Twisted library for LDAP";

--- a/pkgs/development/python-modules/privacyidea/ldap-proxy.nix
+++ b/pkgs/development/python-modules/privacyidea/ldap-proxy.nix
@@ -2,19 +2,18 @@
 
 buildPythonPackage rec {
   pname = "privacyidea-ldap-proxy";
-  version = "0.6.1";
+  version = "0.7.0-dev-py3k";
 
   src = fetchFromGitHub {
     owner = "privacyidea";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1kc1n9wr1a66xd5zvl6dq78xnkqkn5574jpzashc99pvm62dr24j";
+    rev = "fea1907a88352ffd0c0030172d7a5e598c57c251";
+    sha256 = "17mbicdz4cs1qsp3ap1vvglak0xfzncvaff2z07zmszjx7nn7a6z";
   };
 
   propagatedBuildInputs = [ twisted ldaptor configobj ];
 
-  # python 2 zope.interface test import path issues
-  doCheck = false;
+  doCheck = true;
 
   pythonImportsCheck = [ "pi_ldapproxy" ];
 


### PR DESCRIPTION
tests still fail on py3k branch, but this can be used to experiment