### PR TITLE
nixos/prometheus-unbound-exporter: improve config for uds

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/unbound.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/unbound.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
   cfg = config.services.prometheus.exporters.unbound;
+  unboundCfg = config.services.unbound;
 in
 {
   port = 9167;
@@ -51,9 +52,9 @@ in
       '';
     };
   }] ++ [
-    (mkIf config.services.unbound.enable {
+    (mkIf unboundCfg.enable {
       after = [ "unbound.service" ];
-      requires = [ "unbound.service" ];
+      serviceConfig.SupplementaryGroups = mkIf (cfg.fetchType == "uds" && unboundCfg.localControlSocketPath != null) [ "unbound" ];
     })
   ]);
 }

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -667,9 +667,6 @@ let
           enable = true;
           localControlSocketPath = "/run/unbound/unbound.ctl";
         };
-        systemd.services.prometheus-unbound-exporter.serviceConfig = {
-          SupplementaryGroups = [ "unbound" ];
-        };
       };
       exporterTest = ''
         wait_for_unit("unbound.service")


### PR DESCRIPTION
The group "unbound" is now added to SupplementaryGroups of the exporter
service when accessing it locally via uds and the strict "Requires"
option is not neccessary.